### PR TITLE
forward collection addView methods to app methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,17 +212,35 @@ Templates.prototype.create = function(name, opts) {
   this.views[plural] = collection.items || collection.views;
 
   // create loader functions for adding views to this collection
-  this.define(plural, collection.addViews.bind(collection));
-  this.define(single, collection.addView.bind(collection));
+  utils.forward({
+    fromObj: collection,
+    toObj: this,
+    fromMethod: 'addViews',
+    toMethod: plural
+  });
 
-  // decorate loader methods with collection methods
-  this[plural].__proto__ = collection;
-  this[single].__proto__ = collection;
+  utils.forward({
+    fromObj: collection,
+    toObj: this,
+    fromMethod: 'addView',
+    toMethod: single
+  });
 
   // create aliases on the collection for
   // addView/addViews to support chaining
-  collection.define(plural, this[plural]);
-  collection.define(single, this[single]);
+  utils.forward({
+    fromObj: collection,
+    toObj: collection,
+    fromMethod: 'addViews',
+    toMethod: plural
+  });
+
+  utils.forward({
+    fromObj: collection,
+    toObj: collection,
+    fromMethod: 'addView',
+    toMethod: single
+  });
 
   // run collection plugins
   this.plugins.forEach(function (fn) {

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -89,17 +89,14 @@ utils.defaults = function(target) {
   return target;
 };
 
-utils.forward = function (options) {
-  var fromObj = options.fromObj;
-  var toObj = options.toObj;
-  var fromMethod = options.fromMethod;
-  var toMethod = options.toMethod;
-
-  toObj.define(toMethod, {
+utils.forward = function (opts) {
+  var from = opts.fromObj;
+  var to = opts.toObj;
+  to.define(opts.toMethod, {
     configurable: true,
     get: function () {
-      var fn = fromObj[fromMethod].bind(fromObj);
-      fn.__proto__ = fromObj;
+      var fn = from[opts.fromMethod].bind(from);
+      fn.__proto__ = from;
       return fn;
     }
   });

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -88,3 +88,19 @@ utils.defaults = function(target) {
   }
   return target;
 };
+
+utils.forward = function (options) {
+  var fromObj = options.fromObj;
+  var toObj = options.toObj;
+  var fromMethod = options.fromMethod;
+  var toMethod = options.toMethod;
+
+  toObj.define(toMethod, {
+    configurable: true,
+    get: function () {
+      var fn = fromObj[fromMethod].bind(fromObj);
+      fn.__proto__ = fromObj;
+      return fn;
+    }
+  });
+}


### PR DESCRIPTION
Using getters to forward the methods in case any plugins (like `assemble-loader`) want to update the methods on the collection.
