### PR TITLE
Context

### DIFF
--- a/lib/plugins/context.js
+++ b/lib/plugins/context.js
@@ -57,13 +57,13 @@ module.exports = function(app) {
    * @api public
    */
 
-  app.define('context', function(locals) {
+  app.define('context', function(view, locals) {
     // backwards support for `mergeContext`
     var fn = this.options.context || this.options.mergeContext;
     if (typeof fn === 'function') {
       return fn.apply(this, arguments);
     }
-    return utils.merge({}, this.cache.data, locals);
+    return utils.merge({}, this.cache.data, view.context(locals));
   });
 
   /**

--- a/lib/plugins/render.js
+++ b/lib/plugins/render.js
@@ -123,7 +123,7 @@ module.exports = function(proto) {
 
     // get engine options (settings)
     var engineOpts = utils.merge({}, locals.settings, engine.options);
-    var ctx = view._context || view.context(this.context(locals));
+    var ctx = view._context || this.context(view, locals);
 
     // apply layout
     view = this.applyLayout(view);
@@ -177,7 +177,7 @@ module.exports = function(proto) {
     }
 
     locals = utils.merge({settings: {}}, locals);
-    var ctx = view._context || view.context(this.context(locals));
+    var ctx = view._context || this.context(view, locals);
     var app = this;
 
     // handle `preCompile` middleware
@@ -261,7 +261,7 @@ module.exports = function(proto) {
       view = getView(this, view);
     }
 
-    var ctx = view.context(this.context(locals));
+    var ctx = this.context(view, locals);
     var app = this;
 
     // handle `preRender` middleware

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -50,6 +50,36 @@ describe('app.render', function() {
     });
   });
 
+  it('should use global app data in template.', function(cb) {
+    app.data({name: 'CCC'});
+    app.page('a.tmpl', {content: 'a <%= name %> b'});
+    app.render('a.tmpl', function(err, res) {
+      if (err) return cb(err);
+      res.content.should.equal('a CCC b');
+      cb();
+    });
+  });
+
+  it('should use page data in template.', function(cb) {
+    app.data({name: 'CCC'});
+    app.page('a.tmpl', {content: 'a <%= name %> b', data: {name: 'DDD'}});
+    app.render('a.tmpl', function(err, res) {
+      if (err) return cb(err);
+      res.content.should.equal('a DDD b');
+      cb();
+    });
+  });
+
+  it('should use passed in locals in template.', function(cb) {
+    app.data({name: 'CCC'});
+    app.page('a.tmpl', {content: 'a <%= name %> b', data: {name: 'DDD'}});
+    app.render('a.tmpl', {name: 'EEE'}, function(err, res) {
+      if (err) return cb(err);
+      res.content.should.equal('a EEE b');
+      cb();
+    });
+  });
+
   it('should render the same template twice with a helper', function(cb) {
     app.partial('button.tmpl', {content: '<%= name %>'});
     app.page('a.tmpl', {content: 'a <%= partial("button.tmpl", {name: "foo"}) %> <%= partial("button.tmpl", {name: "bar"}) %> b'});
@@ -83,7 +113,7 @@ describe('app.render', function() {
     });
   });
 
-  it.skip('should render the same template multiple times with different engines', function(cb) {
+  it('should render the same template multiple times with different engines', function(cb) {
     app.partial('button.tmpl', {content: '{{title}}', engine: 'hbs'});
     app.partial('foo.hbs', {content: '{{title}}'});
 


### PR DESCRIPTION
This addresses #19 and also passes current and new tests.
This changes the signature of `app.context` to pass the `view` in as the first parameter. This let's us by default to do the following for merging context:

``` js
var ctx = utils.merge({}, app.cache.data, view.locals, view.data, locals);
```

It also lets the user override all the functionality with the `options.context` function:

``` js
app.option('context', function(view, locals) {
  return merge({}, this.cache.data, view.context(locals));
});
```

I think this is the correct way to merge context, but I wanted to open a PR for discussion. This will need to be updated in `assemble-render-file` too.
